### PR TITLE
Make QR codes clickable for digital delivery

### DIFF
--- a/pipeline/data_models.py
+++ b/pipeline/data_models.py
@@ -60,8 +60,8 @@ class ClientRecord:
         Custom pipeline metadata (warnings, flags, etc.).
     qr : Optional[Dict[str, Any]]
         QR code information (if generated):
-        - payload: QR code data string
-        - filename: PNG filename
+        - payload: URL encoded in QR code (same string that becomes QR PNG data)
+        - filename: PNG filename (e.g., "qr_code_00001_1234567890.png")
         - path: Relative path to PNG file
     """
 

--- a/pipeline/generate_notices.py
+++ b/pipeline/generate_notices.py
@@ -304,7 +304,16 @@ def build_template_context(
         qr_filename = f"qr_code_{client.sequence}_{client.client_id}.png"
         qr_path = qr_output_dir / qr_filename
         if qr_path.exists():
-            client_data["qr_code"] = to_root_relative(qr_path)
+            client_data["qr_img"] = to_root_relative(qr_path)
+
+            # Also include QR URL (payload) if available
+            if client.qr and client.qr.get("payload"):
+                client_data["qr_url"] = client.qr["payload"]
+
+    # If qr payload is present but no qr_output_dir, still include it
+    # (may occur if QR generation is disabled but qr payload exists in artifact)
+    if client.qr and client.qr.get("payload") and "qr_url" not in client_data:
+        client_data["qr_url"] = client.qr["payload"]
 
     # Load and translate chart disease header
     chart_diseases_translated = load_and_translate_chart_diseases(client.language)

--- a/templates/en_template.py
+++ b/templates/en_template.py
@@ -75,8 +75,12 @@ Please update Public Health and your childcare centre every time your child rece
   columns: (1fr, auto),
   gutter: 10pt,
   [*If you are choosing not to immunize your child*, a valid medical exemption or statement of conscience or religious belief must be submitted. Links to these forms can be located at #text(fill:conf.wdgteal)[#link("https://www.test-immunization.ca/exemptions")]. Please note this exemption is for childcare only and a new exemption will be required upon enrollment in elementary school.],
-  [#if "qr_code" in client [
-    #image(client.qr_code, width: 2cm)
+  [#if "qr_img" in client [
+    #if "qr_url" in client [
+      #link(client.qr_url)[#image(client.qr_img, width: 3cm)]
+    ] else [
+      #image(client.qr_img, width: 3cm)
+    ]
   ]]
 )
 

--- a/templates/fr_template.py
+++ b/templates/fr_template.py
@@ -76,8 +76,12 @@ Veuillez informer la Santé publique et votre centre de garde d'enfants chaque f
   columns: (1fr, auto),
   gutter: 10pt,
   [*Si vous choisissez de ne pas immuniser votre enfant*, une exemption médicale valide ou une déclaration de conscience ou de croyance religieuse doit être remplie et soumise à la Santé publique. Les liens vers ces formulaires se trouvent à #text(fill:conf.wdgteal)[#link("https://www.test-immunization.ca/exemptions")]. Veuillez noter que cette exemption est uniquement pour la garde d'enfants et qu'une nouvelle exemption sera requise lors de l'inscription à l'école primaire.],
-  [#if "qr_code" in client [
-    #image(client.qr_code, width: 2cm)
+  [#if "qr_img" in client [
+    #if "qr_url" in client [
+      #link(client.qr_url)[#image(client.qr_img, width: 3cm)]
+    ] else [
+      #image(client.qr_img, width: 3cm)
+    ]
   ]]
 )
 


### PR DESCRIPTION
Closes #78 

Now QR codes can be clicked in PDFs, which provides greater flexibility for accessing the link when notices are delivered digitally.

Highlighting here is what is seen in my pdf viewer locally when hovering over the QR code now

<img width="408" height="308" alt="image" src="https://github.com/user-attachments/assets/9ba027ca-7f59-4937-858a-f370b9f52bef" />
