### PR TITLE
Prevent URLS from splitting across lines

### DIFF
--- a/templates/en_template.py
+++ b/templates/en_template.py
@@ -35,8 +35,8 @@ TEMPLATE_PREFIX = """// --- CCEYA NOTICE TEMPLATE (TEST VERSION) --- //
 #set par(justify: false)
 #set page("us-letter")
 
-// Formatting links 
-#show link: underline
+// Formatting links - prevent URLs from splitting across lines
+#show link: it => box(underline(it))
 
 // Font formatting
 #set text(

--- a/templates/fr_template.py
+++ b/templates/fr_template.py
@@ -36,8 +36,8 @@ TEMPLATE_PREFIX = """// --- CCEYA NOTICE TEMPLATE (TEST VERSION) --- //
 #set par(justify: false)
 #set page("us-letter")
 
-// Formatting links 
-#show link: underline
+// Formatting links - prevent URLs from splitting across lines
+#show link: it => box(underline(it))
 
 // Font formatting
 #set text(


### PR DESCRIPTION
Quick one: prevent links/urls in text from splitting across lines in generated pdfs

Closes #76 